### PR TITLE
Store session keys and node info in local storage

### DIFF
--- a/src/hydra.ts
+++ b/src/hydra.ts
@@ -27,8 +27,9 @@ let lucid = await Lucid.new(undefined, "Preprod");
 
 // Load or generate a session key
 
+let persistentSession = true;
 let privateKey = window.localStorage.getItem("hydra-doom-session-key");
-if (privateKey == null) {
+if (persistentSession && privateKey == null) {
   console.warn("Generating new session key");
   privateKey = lucid.utils.generatePrivateKey();
   window.localStorage.setItem("hydra-doom-session-key", privateKey);


### PR DESCRIPTION
This allows us to survive random refreshes and we can invalidate session
keys on-demand using a button or so.
