### PR TITLE
Add watch mode via ?watch query parameter

### DIFF
--- a/src/hydra.ts
+++ b/src/hydra.ts
@@ -10,12 +10,7 @@ import {
 } from "lucid-cardano";
 
 import { HydraProvider } from "./lucid-provider-hydra";
-import {
-  GameData,
-  Player,
-  buildDatum,
-  initialGameData,
-} from "./contract/datum";
+import { Player, buildDatum, initialGameData } from "./contract/datum";
 import { CBOR } from "./contract/cbor";
 import { UTxOResponse, recordValueToAssets } from "./types";
 
@@ -103,7 +98,7 @@ async function getUTxOsAtAddress(address: string): Promise<UTxO[]> {
 }
 // Callbacks from forked doom-wasm
 
-type Cmd = { forwardMove: number };
+type Cmd = { forwardMove: number; sideMove: number };
 
 let latestUTxO: UTxO | null = null;
 let lastTime: number = 0;
@@ -206,12 +201,14 @@ const buildCollateralInput = (txHash: string, txIx: number) => {
 };
 
 const encodeRedeemer = (cmd: Cmd): string => {
-  return Data.to(new Constr(0, [BigInt(cmd.forwardMove)]));
+  return Data.to(
+    new Constr(0, [BigInt(cmd.forwardMove), BigInt(cmd.sideMove)]),
+  );
 };
 
 const decodeRedeemer = (redeemer: string): Cmd => {
   const d = Data.from(redeemer) as Constr<Data>;
-  return { forwardMove: Number(d.fields[0]) };
+  return { forwardMove: Number(d.fields[0]), sideMove: Number(d.fields[1]) };
 };
 
 const buildTx = async (

--- a/src/hydra.ts
+++ b/src/hydra.ts
@@ -166,8 +166,8 @@ export async function hydraRecv(): Promise<Cmd> {
             .datum()
             ?.as_data()
             ?.to_js_value().datum;
+          console.log("received", datum);
           const cmd = { forwardMove: datum.Integer };
-          console.log("received", cmd);
           conn.removeEventListener("message", onMessage);
           res(cmd);
           break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ startButton?.addEventListener("click", () => {
     "-nomusic",
     "-config",
     "default.cfg",
+    "-hydra-send",
+    // "-hydra-recv",
   ];
   callMain(args);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { hydraRecv, hydraSend } from "./hydra";
+import { hydraSend } from "./hydra";
+import { hydraRecv } from "./hydraRecv";
 import { startQueryingAPI } from "./stats";
 import "./styles.css";
 
@@ -25,7 +26,7 @@ startButton?.addEventListener("click", () => {
   if (startButton) {
     startButton.style.display = "none";
   }
-  callMain(commonArgs.concat(["-hydra-send"]));
+  callMain(commonArgs.concat(["-hydra-send", "-hydra-recv"]));
 });
 
 // Watch game

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,20 @@
 import { hydraRecv, hydraSend } from "./hydra";
+import { startQueryingAPI } from "./stats";
 import "./styles.css";
 
-declare var Module: any;
 declare function callMain(args: string[]): void;
 
-const startButton: HTMLButtonElement | null = document.querySelector("#start");
-const txPerSecond: HTMLDataListElement | null = document.querySelector("#txps");
-const bytesPerSecond: HTMLDataListElement | null =
-  document.querySelector("#bps");
-console.log({ txPerSecond, bytesPerSecond });
-
 // Glue together callbacks available from doom-wasm
+(window as any).hydraSend = hydraSend;
+(window as any).hydraRecv = hydraRecv;
 
-// For some reason, injecting into Module doesn't work but this does?
-// @ts-ignore
-window.hydraSend = hydraSend;
-// @ts-ignore
-window.hydraRecv = hydraRecv;
-startButton!.disabled = false;
-
+// Start a new game
+const startButton: HTMLButtonElement | null = document.querySelector("#start");
 startButton?.addEventListener("click", () => {
   // Hide the button
   if (startButton) {
     startButton.style.display = "none";
   }
-
-  Module.hydraSend = hydraSend;
-  Module.hydraRecv = hydraRecv;
-  (window as any).hydraSend = hydraSend;
-  (window as any).hydraRecv = hydraRecv;
-
   var args = [
     "-iwad",
     "doom1.wad",
@@ -40,39 +25,6 @@ startButton?.addEventListener("click", () => {
     "default.cfg",
   ];
   callMain(args);
-  // Start querying the REST API at intervals
-  startQueryingAPI();
 });
 
-// Function to fetch data from the API
-async function fetchData() {
-  try {
-    const response = await fetch("http://3.15.33.186:8000/global");
-    if (!response.ok) {
-      throw new Error("Network response was not ok " + response.statusText);
-    }
-    const data = await response.json();
-    console.log({ data });
-    updateUI(data);
-  } catch (error) {
-    console.error("Fetch error: ", error);
-  }
-}
-
-// Function to update UI with fetched data
-function updateUI(data: any) {
-  if (txPerSecond && data.transactions !== undefined) {
-    txPerSecond.innerText = new Intl.NumberFormat("en").format(
-      data.transactions,
-    );
-  }
-  if (bytesPerSecond && data.bytes !== undefined) {
-    bytesPerSecond.innerText = new Intl.NumberFormat("en").format(data.bytes);
-  }
-}
-
-// Function to start querying the API at intervals
-function startQueryingAPI() {
-  fetchData(); // Initial fetch
-  setInterval(fetchData, 1000); // Fetch data every 5 seconds
-}
+startQueryingAPI();

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,16 @@ declare function callMain(args: string[]): void;
 (window as any).hydraSend = hydraSend;
 (window as any).hydraRecv = hydraRecv;
 
+const commonArgs = [
+  "-iwad",
+  "doom1.wad",
+  "-window",
+  "-nogui",
+  "-nomusic",
+  "-config",
+  "default.cfg",
+];
+
 // Start a new game
 const startButton: HTMLButtonElement | null = document.querySelector("#start");
 startButton?.addEventListener("click", () => {
@@ -15,18 +25,20 @@ startButton?.addEventListener("click", () => {
   if (startButton) {
     startButton.style.display = "none";
   }
-  var args = [
-    "-iwad",
-    "doom1.wad",
-    "-window",
-    "-nogui",
-    "-nomusic",
-    "-config",
-    "default.cfg",
-    "-hydra-send",
-    // "-hydra-recv",
-  ];
-  callMain(args);
+  callMain(commonArgs.concat(["-hydra-send"]));
 });
+
+// Watch game
+// FIXME: prevent /new_game in hydra.ts
+const params = new URLSearchParams(window.location.search);
+if (params.get("watch") != null) {
+  // Hide the button
+  if (startButton) {
+    startButton.style.display = "none";
+  }
+  setTimeout(() => {
+    callMain(commonArgs.concat("-hydra-recv"));
+  }, 1000);
+}
 
 startQueryingAPI();

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -24,7 +24,6 @@ async function fetchData() {
       throw new Error("Network response was not ok " + response.statusText);
     }
     const data = await response.json();
-    console.log({ data });
     updateUI(data);
   } catch (error) {
     console.error("Fetch error: ", error);

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,0 +1,38 @@
+const txPerSecond: HTMLDataListElement | null = document.querySelector("#txps");
+const bytesPerSecond: HTMLDataListElement | null =
+  document.querySelector("#bps");
+console.log({ txPerSecond, bytesPerSecond });
+
+// Function to update UI with fetched data
+function updateUI(data: any) {
+  if (txPerSecond && data.transactions !== undefined) {
+    txPerSecond.innerText = new Intl.NumberFormat("en").format(
+      data.transactions,
+    );
+  }
+  if (bytesPerSecond && data.bytes !== undefined) {
+    bytesPerSecond.innerText = new Intl.NumberFormat("en").format(data.bytes);
+  }
+}
+
+// Function to fetch data from the API
+async function fetchData() {
+  try {
+    // FIXME: should use SERVER_URL (see hydra.ts)
+    const response = await fetch("http://3.15.33.186:8000/global");
+    if (!response.ok) {
+      throw new Error("Network response was not ok " + response.statusText);
+    }
+    const data = await response.json();
+    console.log({ data });
+    updateUI(data);
+  } catch (error) {
+    console.error("Fetch error: ", error);
+  }
+}
+
+// Start querying the REST API at intervals
+export function startQueryingAPI() {
+  fetchData(); // Initial fetch
+  setInterval(fetchData, 1000); // Fetch data every 5 seconds
+}


### PR DESCRIPTION
Requires https://github.com/cardano-scaling/doom-wasm/pull/5

* Send and receive inputs in a normal game (like before)
* Receive inputs when in `/?watch` mode
* Encode and decode `Cmd` into/from redeemer