### PR TITLE
fix: hook up game url with real game id

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <link rel="preload" as="fetch" href="websockets-doom.wasm">
-    <link rel="preload" as="fetch" href="freedoom2.wad">
-    <link rel="preload" as="fetch" href="Cardano.wad">
-    <link rel="preload" as="fetch" href="default.cfg">
+    <link rel="preload" as="fetch" href="websockets-doom.wasm" />
+    <link rel="preload" as="fetch" href="freedoom2.wad" />
+    <link rel="preload" as="fetch" href="Cardano.wad" />
+    <link rel="preload" as="fetch" href="default.cfg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hydra Doom Multiplayer</title>
   </head>

--- a/src/components/GameView/GameView.tsx
+++ b/src/components/GameView/GameView.tsx
@@ -1,5 +1,3 @@
-import { MdContentCopy } from "react-icons/md";
-import { ClipboardAPI, useClipboard } from "use-clipboard-copy";
 import Card from "../Card";
 import DoomCanvas from "../DoomCanvas";
 import GlobalTPS from "../GlobalTPS";
@@ -9,24 +7,8 @@ import MusicPlayer from "../MusicPlayer";
 import RestartButton from "../RestartButton";
 import StatsCard from "../StatsCard";
 import TopLinks from "../TopLinks";
-import { useCallback } from "react";
-import { FaRegCircleCheck } from "react-icons/fa6";
-import { useAppContext } from "../../context/useAppContext";
-import { EGameType } from "../../types";
 
 const GameView = () => {
-  const { gameData } = useAppContext();
-  const urlClipboard = useClipboard({ copiedTimeout: 1500 });
-
-  const urlClipboardCopy = useCallback(
-    (clipboard: ClipboardAPI, value: string) => {
-      clipboard.copy(value);
-    },
-    [],
-  );
-
-  const gameUrl = `${window.location.origin}/join/1efabc`;
-
   return (
     <Layout>
       <TopLinks />
@@ -50,29 +32,7 @@ const GameView = () => {
           <HydraHeadLiveTxs />
         </div>
         <div className="flex flex-col gap-6">
-          <Card className="h-[40rem]">
-            <DoomCanvas />
-          </Card>
-          {gameData.type === EGameType.HOST && (
-            <Card className="px-4 py-2 text-center text-xl text-white flex items-center gap-2 justify-center">
-              Share this URL with friends{" "}
-              <a
-                className="text-yellow-400 underline"
-                href={gameUrl}
-                target="_blank"
-              >
-                {gameUrl}
-              </a>
-              {urlClipboard.copied ? (
-                <FaRegCircleCheck className="text-green-600" />
-              ) : (
-                <MdContentCopy
-                  role="button"
-                  onClick={() => urlClipboardCopy(urlClipboard, gameUrl)}
-                />
-              )}
-            </Card>
-          )}
+          <DoomCanvas />
         </div>
         <div className="w-80 flex flex-col gap-4">
           <GlobalTPS size="sm" titleAlign="left" />

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface GameStatistics {
 }
 
 export interface NewGameResponse {
+  game_id: string;
   ip: string;
   player_state: string;
 }


### PR DESCRIPTION
This pull request includes several changes to the `DoomCanvas` component and related files to enhance functionality and streamline the codebase. The most significant changes involve the addition of clipboard functionality for sharing game URLs, restructuring the `GameView` component, and minor updates to the `index.html` file. Below is a detailed list of the most important changes:

### Enhancements to `DoomCanvas` Component:

* Added clipboard functionality to copy the game URL, including new imports (`FaRegCircleCheck`, `MdContentCopy`, `ClipboardAPI`, `useClipboard`) and a `useCallback` function for copying the URL. [[1]](diffhunk://#diff-684f7a4dc55d5f4b2f1ebd8e90ea6a242b632a130fba45360cbdf3afd851c384L1-R12) [[2]](diffhunk://#diff-684f7a4dc55d5f4b2f1ebd8e90ea6a242b632a130fba45360cbdf3afd851c384R21) [[3]](diffhunk://#diff-684f7a4dc55d5f4b2f1ebd8e90ea6a242b632a130fba45360cbdf3afd851c384R35-R43)
* Updated the component's return statement to include conditional rendering for the game URL sharing feature for the host.

### Restructuring `GameView` Component:

* Removed redundant imports and the game URL sharing logic, which is now handled within the `DoomCanvas` component. [[1]](diffhunk://#diff-41ded2d05b189214130098a13adda4d0fefd1918047aea5b971478e782d11c05L1-L2) [[2]](diffhunk://#diff-41ded2d05b189214130098a13adda4d0fefd1918047aea5b971478e782d11c05L12-L29) [[3]](diffhunk://#diff-41ded2d05b189214130098a13adda4d0fefd1918047aea5b971478e782d11c05L53-L75)

### Minor Updates:

* Corrected the self-closing tags in `index.html` for better HTML syntax.
* Added `game_id` to the `NewGameResponse` interface in `src/types.ts` to support the new functionality.