### PR TITLE
feat: create slider to select number of player and bots

### DIFF
--- a/src/components/SetNameModal/SetNameModal.tsx
+++ b/src/components/SetNameModal/SetNameModal.tsx
@@ -5,6 +5,7 @@ import { FaArrowRotateRight } from "react-icons/fa6";
 import Button from "../Button";
 import { generateRandomName } from "./petNameWords";
 import { useAppContext } from "../../context/useAppContext";
+import { MAX_PLAYERS } from "../../constants";
 
 interface SetNameModalProps extends Omit<ModalProps, "children"> {
   submit: () => void;
@@ -17,7 +18,8 @@ const SetNameModal: FC<SetNameModalProps> = ({
   submit,
   title,
 }) => {
-  const { setGameData, gameData, accountData } = useAppContext();
+  const { setGameData, gameData, accountData, players, setPlayers, bots } =
+    useAppContext();
 
   useEffect(() => {
     const petName = accountData ? accountData.auth_name : generateRandomName();
@@ -34,6 +36,10 @@ const SetNameModal: FC<SetNameModalProps> = ({
 
   const handleGenerateName = () => {
     setGameData((prev) => ({ ...prev, petName: generateRandomName() }));
+  };
+
+  const handleSliderChange = (event) => {
+    setPlayers(Number(event.target.value));
   };
 
   const isButtonDisabled =
@@ -84,7 +90,34 @@ const SetNameModal: FC<SetNameModalProps> = ({
             </button>
           </div>
         )}
-
+        {title !== "Join Multiplayer" && (
+          <div className="w-3/4">
+            <h2 className="text-4xl font-bold mb-4 text-center">
+              Number of Players:
+            </h2>
+            <input
+              className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer range-slider"
+              max={MAX_PLAYERS}
+              min="1"
+              onChange={handleSliderChange}
+              type="range"
+              value={players}
+            />
+            <div className="flex justify-between text-base text-gray-400 mb-6">
+              {Array.from({ length: MAX_PLAYERS }, (_, i) => i + 1).map((i) => (
+                <span key={i}>{i}</span>
+              ))}
+            </div>
+            <div className="flex justify-between text-3xl">
+              <p className="">
+                Players: <span className="font-semibold">{players}</span>
+              </p>
+              <p className="">
+                Bots: <span className="font-semibold">{bots}</span>
+              </p>
+            </div>
+          </div>
+        )}
         <Button
           className="text-2xl w-40 h-12"
           disabled={isButtonDisabled}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,3 +9,4 @@ export const TIC_RATE_MAGIC = 35; // 35 is the ticrate in DOOM WASM they use to 
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 export const API_KEY = import.meta.env.VITE_API_KEY;
 export const SESSION_REFERENCE_KEY = "session-reference";
+export const MAX_PLAYERS = 4;

--- a/src/context/AppContextProvider.tsx
+++ b/src/context/AppContextProvider.tsx
@@ -3,7 +3,7 @@ import { AppContext } from "./useAppContext";
 import { Account, AuthResponse, EGameType } from "../types";
 import useBestRegion from "../hooks/useBestRegion";
 import useKeys from "../hooks/useKeys";
-import { REGIONS } from "../constants";
+import { MAX_PLAYERS, REGIONS } from "../constants";
 import { useQuery } from "@tanstack/react-query";
 import { useSessionReferenceKeyCache } from "../utils/localStorage";
 import { checkSignin } from "../utils/requests";
@@ -18,6 +18,8 @@ const AppContextProvider: FC<PropsWithChildren> = ({ children }) => {
     type: EGameType.SOLO,
   });
   const [accountData, setAccountData] = useState<Account>();
+  const [players, setPlayers] = useState(1);
+  const bots = MAX_PLAYERS - players;
 
   const { data: userData, isLoading: isLoadingUserData } =
     useQuery<AuthResponse>({
@@ -40,14 +42,17 @@ const AppContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const value = useMemo(
     () => ({
       accountData,
+      bots,
       gameData,
       isLoadingUserData,
       keys,
+      players,
       region: bestRegion,
       setAccountData,
       setGameData,
+      setPlayers,
     }),
-    [accountData, gameData, keys, bestRegion, isLoadingUserData],
+    [accountData, bots, gameData, isLoadingUserData, keys, players, bestRegion],
   );
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/src/context/useAppContext.ts
+++ b/src/context/useAppContext.ts
@@ -1,24 +1,31 @@
 import { createContext, Dispatch, useContext } from "react";
 import { Account, EGameType, GameData, Keys } from "../types";
+import { MAX_PLAYERS } from "../constants";
 
 interface AppContextInterface {
   accountData?: Account;
+  bots: number;
   gameData: GameData;
   isLoadingUserData: boolean;
   keys: Keys | null;
+  players: number;
   region: string | null;
   setAccountData: Dispatch<React.SetStateAction<Account | undefined>>;
   setGameData: Dispatch<React.SetStateAction<GameData>>;
+  setPlayers: Dispatch<React.SetStateAction<number>>;
 }
 
 export const AppContext = createContext<AppContextInterface>({
   accountData: undefined,
+  bots: MAX_PLAYERS - 1,
   gameData: { petName: "", code: "", type: EGameType.SOLO },
   isLoadingUserData: false,
   keys: null,
+  players: 1,
   region: null,
   setAccountData: () => {},
   setGameData: () => {},
+  setPlayers: () => {},
 });
 
 export const useAppContext = () => {

--- a/src/index.css
+++ b/src/index.css
@@ -36,3 +36,33 @@
     font-family: "Less Perfect DOS VGA", monospace;
   }
 }
+
+.range-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 24px;
+  height: 24px;
+  background: #d40018;
+  border-radius: 50%;
+  cursor: pointer;
+  margin-top: -11px;
+}
+
+.range-slider::-webkit-slider-runnable-track {
+  height: 2px;
+  background: #d1d5db;
+}
+
+.range-slider::-moz-range-thumb {
+  width: 24px;
+  height: 24px;
+  background: #d40018;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.range-slider::-moz-range-track {
+  height: 2px;
+  background: #d1d5db;
+}


### PR DESCRIPTION
This pull request introduces changes to the `SetNameModal` component to allow users to set the number of players and bots, as well as updates to the context and constants to support this new functionality. The most important changes include adding a slider for player selection, updating the context to manage player and bot counts, and styling the slider.

### Changes to `SetNameModal` component:

* Added a slider to select the number of players and display the number of bots in the `SetNameModal` component. (`src/components/SetNameModal/SetNameModal.tsx`)
* Updated the `useAppContext` hook to include `players`, `setPlayers`, and `bots` in the context. (`src/components/SetNameModal/SetNameModal.tsx`)

### Updates to context:

* Added `players` and `bots` state and methods to the `AppContextProvider` to manage the number of players and bots. (`src/context/AppContextProvider.tsx`) [[1]](diffhunk://#diff-e49e9ee75a1f24a197cabb5cc3d100526d6f540e07558642fabc92d93adc88dcR21-R22) [[2]](diffhunk://#diff-e49e9ee75a1f24a197cabb5cc3d100526d6f540e07558642fabc92d93adc88dcR45-R55)
* Updated the `AppContext` interface and default values to include `players`, `setPlayers`, and `bots`. (`src/context/useAppContext.ts`)

### Constants:

* Added `MAX_PLAYERS` constant to define the maximum number of players. (`src/constants.ts`)

### Styling:

* Added custom styles for the range slider to `src/index.css`. (`src/index.css`)