### PR TITLE
fix: game not connecting due to app rendering twice

### DIFF
--- a/src/components/DoomCanvas/DoomCanvas.tsx
+++ b/src/components/DoomCanvas/DoomCanvas.tsx
@@ -14,7 +14,6 @@ import { HydraMultiplayerClient } from "../../utils/HydraMultiplayer/client.js";
 
 const DoomCanvas: React.FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const isEffectRan = useRef(false);
   const isGameDataFetched = useRef(false);
   const {
     gameData: { code, petName, type },
@@ -57,10 +56,6 @@ const DoomCanvas: React.FC = () => {
   useEffect(() => {
     if (!address) return;
     if (type !== EGameType.SOLO && !data?.ip) return;
-
-    // Prevent effect from running twice
-    if (isEffectRan.current) return;
-    isEffectRan.current = true;
 
     const canvas = canvasRef.current;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,5 @@
-import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
This pull request includes changes to the `DoomCanvas` component and the main application entry point. The most important changes involve removing unnecessary code and simplifying the rendering process.

Code simplification in `DoomCanvas` component:

* Removed the `isEffectRan` ref and its associated logic, which was previously used to prevent an effect from running twice. (`src/components/DoomCanvas/DoomCanvas.tsx`) [[1]](diffhunk://#diff-684f7a4dc55d5f4b2f1ebd8e90ea6a242b632a130fba45360cbdf3afd851c384L17) [[2]](diffhunk://#diff-684f7a4dc55d5f4b2f1ebd8e90ea6a242b632a130fba45360cbdf3afd851c384L61-L64)

Simplification of the main application entry point:

* Removed the `StrictMode` wrapper from the `createRoot` rendering process in `src/main.tsx`. (`src/main.tsx`)