### PR TITLE
feat: update region based on code prefix

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,12 +5,12 @@ export const GLOBAL_MAX_SPEED = 30 * 100;
 export const HANDLE_CACHE_KEY = "player-handle-cache";
 export const MAX_SPEED = 40;
 export const REGIONS = [
-  { name: "Virginia, NA", value: "us-east-1" },
-  { name: "Frankfurt, Europe", value: "eu-central-1" },
-  { name: "Oregon, NA", value: "us-west-2" },
-  { name: "Singapore", value: "ap-southeast-1" },
-  { name: "São Paulo, SA", value: "sa-east-1" },
-  { name: "Cape Town, Africa", value: "af-south-1" },
+  { name: "Virginia, NA", value: "us-east-1", prefix: "a" },
+  { name: "Frankfurt, Europe", value: "eu-central-1", prefix: "b" },
+  { name: "Oregon, NA", value: "us-west-2", prefix: "c" },
+  { name: "Singapore", value: "ap-southeast-1", prefix: "d" },
+  { name: "São Paulo, SA", value: "sa-east-1", prefix: "e" },
+  { name: "Cape Town, Africa", value: "af-south-1", prefix: "f" },
 ];
 export const TIC_RATE_MAGIC = 35; // 35 is the ticrate in DOOM WASM they use to calculate time.
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;

--- a/src/context/AppContextProvider.tsx
+++ b/src/context/AppContextProvider.tsx
@@ -13,8 +13,11 @@ import { REGIONS } from "../constants";
 import { useQuery } from "@tanstack/react-query";
 import { useSessionReferenceKeyCache } from "../utils/localStorage";
 import { checkSignin, fetchGlobalStats } from "../utils/requests";
+import { getRegionWithPrefix } from "../utils/game";
 
 const AppContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const pathSegments = window.location.pathname.split("/").filter(Boolean);
+  const code = pathSegments[1];
   const [sessionReference, setSessionReference] = useSessionReferenceKeyCache();
   const keys = useKeys();
   const { bestRegion } = useBestRegion(REGIONS);
@@ -55,8 +58,13 @@ const AppContextProvider: FC<PropsWithChildren> = ({ children }) => {
   }, [setSessionReference, userData]);
 
   useEffect(() => {
-    if (bestRegion) setRegion(bestRegion);
-  }, [bestRegion]);
+    const newRegion = getRegionWithPrefix(gameData.code[0]);
+    if (newRegion) setRegion(newRegion);
+  }, [gameData.code]);
+
+  useEffect(() => {
+    if (bestRegion && !code) setRegion(bestRegion);
+  }, [bestRegion, code]);
 
   const value = useMemo(
     () => ({

--- a/src/index.css
+++ b/src/index.css
@@ -55,6 +55,6 @@
   left: 23px;
   width: 113px;
   height: 19px;
-  background: url("speedometer-tick.png");
+  background: url("/speedometer-tick.png");
   background-size: cover;
 }

--- a/src/utils/game.ts
+++ b/src/utils/game.ts
@@ -1,3 +1,4 @@
+import { REGIONS } from "../constants";
 import { EGameType, GameData } from "../types";
 
 export const getArgs = ({ type, petName }: GameData) => {
@@ -26,4 +27,8 @@ export const getArgs = ({ type, petName }: GameData) => {
   if (petName) args.push("-pet", petName);
 
   return args;
+};
+
+export const getRegionWithPrefix = (prefix: string) => {
+  return REGIONS.find((r) => prefix === r.prefix);
 };


### PR DESCRIPTION
This pull request includes several changes to the codebase to enhance region handling and fix a minor issue with the background image path. The most important changes include adding a prefix to region definitions, updating the `AppContextProvider` to utilize the new region prefix, and fixing the background image path in the CSS file.

Enhancements to region handling:

* [`src/constants.ts`](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L8-R13): Added a `prefix` property to each region in the `REGIONS` array.
* [`src/context/AppContextProvider.tsx`](diffhunk://#diff-e49e9ee75a1f24a197cabb5cc3d100526d6f540e07558642fabc92d93adc88dcR16-R20): Updated the `AppContextProvider` to include logic for setting the region based on the new `prefix` property. [[1]](diffhunk://#diff-e49e9ee75a1f24a197cabb5cc3d100526d6f540e07558642fabc92d93adc88dcR16-R20) [[2]](diffhunk://#diff-e49e9ee75a1f24a197cabb5cc3d100526d6f540e07558642fabc92d93adc88dcL58-R67)
* [`src/utils/game.ts`](diffhunk://#diff-63a7d26cade07ab7ae457c49849abd6986838ed019ef35f9fda6d7e51810f56eR1): Added a new utility function `getRegionWithPrefix` to find a region by its prefix. [[1]](diffhunk://#diff-63a7d26cade07ab7ae457c49849abd6986838ed019ef35f9fda6d7e51810f56eR1) [[2]](diffhunk://#diff-63a7d26cade07ab7ae457c49849abd6986838ed019ef35f9fda6d7e51810f56eR31-R34)

Fixes:

* [`src/index.css`](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL58-R58): Corrected the background image path for the speedometer tick.